### PR TITLE
Make generatorFn more versatile

### DIFF
--- a/vlist.js
+++ b/vlist.js
@@ -82,7 +82,7 @@ function VirtualList(config) {
 VirtualList.prototype.createRow = function(i) {
   var item;
   if (this.generatorFn)
-    item = this.generatorFn(i);
+    item = this.generatorFn(i, this.items[i]);
   else if (this.items) {
     if (typeof this.items[i] === 'string') {
       var itemText = document.createTextNode(this.items[i]);


### PR DESCRIPTION
Pass the items array element as second parameter to generatorFn.  This way `items` can be an array of anything (Backbone.Models, jQuery collections, etc.), and `generatorFn` can handle it however it wants.

Example:

```
var i, bigList = [];
for (i = 0; i < 10000; i++) {
  bigList.push({name: "Test Item " + i, desc: "I'm a description"});
}

var list = new VirtualList({
  h: window.innerHeight,
  itemHeight: 30,
  items: bigList,
  generatorFn: function(idx, row) {
    return $("<div>", {text: row.name + " -|- " + row.desc, css: {height: "30px"}})[0];
  }
});
```
